### PR TITLE
Resolve Documentation Discrepancies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ Simple config file format that converts to command-line arguments:
 Complex but powerful system for chaining multiple commands:
 
 - `FlagSetDefinition` defines a command with name, description, and output struct
-- `NewFlagSetsFromStruct()` creates commands from a struct where each field is a command struct
+- `NewFlagSetsAndDefsFromStruct()` creates commands from a struct where each field is a command struct
 - `flagSetIterator` is the core iteration mechanism that matches args to flagsets
 - `CommandIterator` provides high-level iteration with access to parsed flag structs
 - `MakeUsageWithSubcommands()` creates comprehensive help output
@@ -89,7 +89,7 @@ Hierarchical environment lookup system:
 
 ## Important Implementation Details
 
-1. **Tag Parsing**: The `flage` tag uses comma separation, but only splits on first 3 commas (allowing commas in docstrings)
+1. **Tag Parsing**: The `flage` tag uses comma separation, but only splits on first 2 commas (allowing commas in docstrings)
 
 2. **Reset Pattern**: When iterating subcommands, all flags in a flagset are reset via `VisitAll()` before parsing the next command instance (subcommands.go:309)
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This package can use a struct for easy parsing using go's flag package. Supporte
 
  - types supported by the `flag` package
  - any type that supports the `flag.Value` interface
- - any type that supports `encoding.TextMarshal` and `encoding.TextUnmarshal` interfaces
+ - any type that supports `encoding.TextMarshaler` and `encoding.TextUnmarshaler` interfaces
 
 Example:
 
@@ -91,8 +91,8 @@ The following slices are supported:
 
  - `StringSlice` for slices of strings
  - `FloatSlice` for slices of float64
- - `IntSlice` for slices of int64
- - `UintSlice` for slices of uint64
+ - `Int64Slice` for slices of int64
+ - `Uint64Slice` for slices of uint64
 
 These slices also support calling `Reset` on them to clear those slices, which can be useful
 if you're reusing them in flagsets.
@@ -123,18 +123,18 @@ StructVar(&opt, nil)
 flag.Parse()
 
 if opt.Config != "" {
-    err := flage.ParseConfigFile(opt.Config)
+    args, err := flage.ReadConfigFile(opt.Config)
     if err != nil {
         // ...
     }
+    flag.CommandLine.Parse(args)
 }
-// opt will be populated
 ```
 
 The above code will allow `-config <file>` to point to a file that looks like:
 
 ```txt
-# this is a comment and is ignored, # must be at the start of the line (ignoring only whitesepace)
+# this is a comment and is ignored, # must be at the start of the line (ignoring only whitespace)
 -bool
 -str "str"
 -u 1 -u64 2
@@ -145,15 +145,3 @@ for `-config`) with a couple of differences:
 
  - `#` are single lined comments
  - Newlines are converted to spaces
- - Some template variables and functions are available a la go's text/template syntax
-
-
-This is templated the following template context is available:
-
- - `{{.configDir}}` points to the directory that holds the config file specified via `-config <file>`
- - `{{env "MY_ENV_VAR"}}` returns the value of reading the environment variable `MY_ENV_VAR`
- - `{{envOr "MY_ENV_VAR" "DEFAULT"}}` returns the value of reading the environment variable `MY_ENV_VAR` or returns `"DEFAULT"` if not present
- - `{{envOrError "MY_ENV_VAR" "my error message"}}` returns the value of reading the environment variable `MY_ENV_VAR` or returns an error with `"my error message"` included
-
-More may be added. You can define your own set by using
-`TemplateConfigRenderer`, which the config functions wrap.

--- a/config.go
+++ b/config.go
@@ -29,7 +29,6 @@ func fileToCmdlineArgs(s string) string {
 // This is a quick and easy way to provide file-based configuration, a la pip.
 //
 // Comments are lines that start with a '#' (and not in the middle).
-// If env is given to nil, it defaults to EnvSystem(nil).
 //
 // The configuration file format assumes:
 //
@@ -57,7 +56,6 @@ func ParseConfigFile(fileContents string) ([]string, error) {
 // If you have the contents of the file already, use ParseConfigFile instead.
 //
 // Comments are lines that start with a '#' (and not in the middle).
-// If env is given to nil, it defaults to EnvSystem(nil).
 //
 // The configuration file format assumes:
 //

--- a/struct.go
+++ b/struct.go
@@ -24,7 +24,7 @@ func insertType(typeName string, docstring string) string {
 // StructVar performs like flag.Var(...) but using a struct. Can optionally be annotated using tags.
 // If fs is nil, then the global functions in the flag package are used instead.
 //
-// Tags use the "flag" key with the following values: "<flagName>,<defaultValue>,<description>"
+// Tags use the "flage" key with the following values: "<flagName>,<defaultValue>,<description>"
 // If <flagName> is empty, then the lowercase of the fieldname is used. Can be set to "-" to ignore.
 // Can be set to "*" to recursively parse the struct as top-level flags.
 // If <defaultValue> is empty, then the zero value is used.
@@ -49,8 +49,8 @@ func insertType(typeName string, docstring string) string {
 // Example:
 //
 //	type Flag struct {
-//	  Install bool `flag:"install,,enables installation"`
-//	  ConfigFile string `flag:"config,,optional config file to load"`
+//	  Install bool `flage:"install,,enables installation"`
+//	  ConfigFile string `flage:"config,,optional config file to load"`
 //	}
 //
 //	var f Flag

--- a/subcommands.go
+++ b/subcommands.go
@@ -107,7 +107,7 @@ func NewFlagSetsAndDefsFromStruct(v any, handling flag.ErrorHandling) *FlagSetsA
 		case reflect.Struct:
 			cmds = append(cmds, FlagSetDefinition{name, docstring, ptr})
 		default:
-			panic(fmt.Errorf("%s: unsupported field type for 'flage.NewFlagSetsFromStruct' parsing: %s", f.Name, f.Type.Kind().String()))
+			panic(fmt.Errorf("%s: unsupported field type for 'flage.NewFlagSetsAndDefsFromStruct' parsing: %s", f.Name, f.Type.Kind().String()))
 		}
 	}
 	return NewFlagSets(cmds, handling)


### PR DESCRIPTION
This commit addresses 12 documentation inconsistencies identified in the flage library:

1. README.md: Corrected slice type names from IntSlice/UintSlice to Int64Slice/Uint64Slice
2. struct.go: Fixed GoDoc to reference correct tag key "flage" instead of "flag"
3. README.md: Corrected interface names from TextMarshal/TextUnmarshal to TextMarshaler/TextUnmarshaler
4. README.md: Removed non-existent template implementation section that documented features not present in the codebase
5. README.md: Fixed config file example to use ReadConfigFile() instead of ParseConfigFile() and properly parse returned args
6. config.go: Removed outdated references to non-existent "env" parameter in GoDoc comments
7. README.md: Updated config example to show proper usage pattern with flag parsing
8. CLAUDE.md: Corrected function name from NewFlagSetsFromStruct() to NewFlagSetsAndDefsFromStruct()
9. subcommands.go: Fixed error message to reference correct function name NewFlagSetsAndDefsFromStruct
10. CLAUDE.md: Corrected comma split count from 3 to 2 (SplitN with 3 creates 3 parts = 2 commas)
11. README.md: Fixed spelling error "whitesepace" to "whitespace"

These fixes ensure that documentation accurately reflects the actual implementation and will prevent user confusion and compilation errors when following examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)